### PR TITLE
Extend the use of config_expr

### DIFF
--- a/metaflow/_vendor/click/core.py
+++ b/metaflow/_vendor/click/core.py
@@ -719,7 +719,7 @@ class BaseCommand(object):
         prog_name=None,
         complete_var=None,
         standalone_mode=True,
-        **extra
+        **extra,
     ):
         """This is the way to invoke a script with all the bells and
         whistles as a command line application.  This will always terminate
@@ -1101,7 +1101,7 @@ class MultiCommand(Command):
         subcommand_metavar=None,
         chain=False,
         result_callback=None,
-        **attrs
+        **attrs,
     ):
         Command.__init__(self, name, **attrs)
         if no_args_is_help is None:
@@ -1463,6 +1463,7 @@ class Parameter(object):
         parameter. The old callback format will still work, but it will
         raise a warning to give you a chance to migrate the code easier.
     """
+
     param_type_name = "parameter"
 
     def __init__(
@@ -1708,7 +1709,7 @@ class Option(Parameter):
         hidden=False,
         show_choices=True,
         show_envvar=False,
-        **attrs
+        **attrs,
     ):
         default_is_missing = attrs.get("default", _missing) is _missing
         Parameter.__init__(self, param_decls, type=type, **attrs)

--- a/metaflow/decorators.py
+++ b/metaflow/decorators.py
@@ -152,7 +152,7 @@ class Decorator(object):
         # Note that by design, later values override previous ones.
         self.attributes, new_user_attributes = unpack_delayed_evaluator(self.attributes)
         self._user_defined_attributes.update(new_user_attributes)
-        self.attributes = resolve_delayed_evaluator(self.attributes)
+        self.attributes = resolve_delayed_evaluator(self.attributes, to_dict=True)
 
         self._ran_init = True
 
@@ -638,7 +638,7 @@ StepFlag = NewType("StepFlag", bool)
 
 @overload
 def step(
-    f: Callable[[FlowSpecDerived], None]
+    f: Callable[[FlowSpecDerived], None],
 ) -> Callable[[FlowSpecDerived, StepFlag], None]: ...
 
 
@@ -649,7 +649,7 @@ def step(
 
 
 def step(
-    f: Union[Callable[[FlowSpecDerived], None], Callable[[FlowSpecDerived, Any], None]]
+    f: Union[Callable[[FlowSpecDerived], None], Callable[[FlowSpecDerived, Any], None]],
 ):
     """
     Marks a method in a FlowSpec as a Metaflow Step. Note that this

--- a/metaflow/parameters.py
+++ b/metaflow/parameters.py
@@ -373,7 +373,7 @@ class Parameter(object):
         # Do it one item at a time so errors are ignored at that level (as opposed to
         # at the entire kwargs level)
         self.kwargs = {
-            k: resolve_delayed_evaluator(v, ignore_errors=ignore_errors)
+            k: resolve_delayed_evaluator(v, ignore_errors=ignore_errors, to_dict=True)
             for k, v in self.kwargs.items()
         }
 
@@ -382,7 +382,7 @@ class Parameter(object):
         for key, value in self._override_kwargs.items():
             if value is not None:
                 self.kwargs[key] = resolve_delayed_evaluator(
-                    value, ignore_errors=ignore_errors
+                    value, ignore_errors=ignore_errors, to_dict=True
                 )
         # Set two default values if no-one specified them
         self.kwargs.setdefault("required", False)

--- a/metaflow/runner/click_api.py
+++ b/metaflow/runner/click_api.py
@@ -467,9 +467,14 @@ class MetaflowAPI(object):
                     config_file = defaults.get("config")
 
                 if config_file:
-                    config_file = map(
-                        lambda x: (x[0], ConvertPath.convert_value(x[1], is_default)),
-                        config_file,
+                    config_file = dict(
+                        map(
+                            lambda x: (
+                                x[0],
+                                ConvertPath.convert_value(x[1], is_default),
+                            ),
+                            config_file,
+                        )
                     )
 
                 is_default = False
@@ -479,12 +484,14 @@ class MetaflowAPI(object):
                     config_value = defaults.get("config_value")
 
                 if config_value:
-                    config_value = map(
-                        lambda x: (
-                            x[0],
-                            ConvertDictOrStr.convert_value(x[1], is_default),
-                        ),
-                        config_value,
+                    config_value = dict(
+                        map(
+                            lambda x: (
+                                x[0],
+                                ConvertDictOrStr.convert_value(x[1], is_default),
+                            ),
+                            config_value,
+                        )
                     )
 
                 if (config_file is None) ^ (config_value is None):

--- a/metaflow/runner/metaflow_runner.py
+++ b/metaflow/runner/metaflow_runner.py
@@ -7,12 +7,15 @@ from typing import Dict, Iterator, Optional, Tuple
 
 from metaflow import Run
 
+from metaflow.metaflow_config import CLICK_API_PROCESS_CONFIG
+
 from metaflow.plugins import get_runner_cli
 
 from .utils import (
     temporary_fifo,
     handle_timeout,
     async_handle_timeout,
+    with_dir,
 )
 from .subprocess_manager import CommandManager, SubprocessManager
 
@@ -299,7 +302,7 @@ class Runner(metaclass=RunnerMeta):
         if profile:
             self.env_vars["METAFLOW_PROFILE"] = profile
 
-        self.cwd = cwd
+        self.cwd = cwd or os.getcwd()
         self.file_read_timeout = file_read_timeout
         self.spm = SubprocessManager()
         self.top_level_kwargs = kwargs
@@ -359,9 +362,15 @@ class Runner(metaclass=RunnerMeta):
             ExecutingRun containing the results of the run.
         """
         with temporary_fifo() as (attribute_file_path, attribute_file_fd):
-            command = self.api(**self.top_level_kwargs).run(
-                runner_attribute_file=attribute_file_path, **kwargs
-            )
+            if CLICK_API_PROCESS_CONFIG:
+                with with_dir(self.cwd):
+                    command = self.api(**self.top_level_kwargs).run(
+                        runner_attribute_file=attribute_file_path, **kwargs
+                    )
+            else:
+                command = self.api(**self.top_level_kwargs).run(
+                    runner_attribute_file=attribute_file_path, **kwargs
+                )
 
             pid = self.spm.run_command(
                 [sys.executable, *command],
@@ -390,9 +399,15 @@ class Runner(metaclass=RunnerMeta):
             ExecutingRun containing the results of the resumed run.
         """
         with temporary_fifo() as (attribute_file_path, attribute_file_fd):
-            command = self.api(**self.top_level_kwargs).resume(
-                runner_attribute_file=attribute_file_path, **kwargs
-            )
+            if CLICK_API_PROCESS_CONFIG:
+                with with_dir(self.cwd):
+                    command = self.api(**self.top_level_kwargs).resume(
+                        runner_attribute_file=attribute_file_path, **kwargs
+                    )
+            else:
+                command = self.api(**self.top_level_kwargs).resume(
+                    runner_attribute_file=attribute_file_path, **kwargs
+                )
 
             pid = self.spm.run_command(
                 [sys.executable, *command],
@@ -423,9 +438,15 @@ class Runner(metaclass=RunnerMeta):
             ExecutingRun representing the run that was started.
         """
         with temporary_fifo() as (attribute_file_path, attribute_file_fd):
-            command = self.api(**self.top_level_kwargs).run(
-                runner_attribute_file=attribute_file_path, **kwargs
-            )
+            if CLICK_API_PROCESS_CONFIG:
+                with with_dir(self.cwd):
+                    command = self.api(**self.top_level_kwargs).run(
+                        runner_attribute_file=attribute_file_path, **kwargs
+                    )
+            else:
+                command = self.api(**self.top_level_kwargs).run(
+                    runner_attribute_file=attribute_file_path, **kwargs
+                )
 
             pid = await self.spm.async_run_command(
                 [sys.executable, *command],
@@ -455,9 +476,15 @@ class Runner(metaclass=RunnerMeta):
             ExecutingRun representing the resumed run that was started.
         """
         with temporary_fifo() as (attribute_file_path, attribute_file_fd):
-            command = self.api(**self.top_level_kwargs).resume(
-                runner_attribute_file=attribute_file_path, **kwargs
-            )
+            if CLICK_API_PROCESS_CONFIG:
+                with with_dir(self.cwd):
+                    command = self.api(**self.top_level_kwargs).resume(
+                        runner_attribute_file=attribute_file_path, **kwargs
+                    )
+            else:
+                command = self.api(**self.top_level_kwargs).resume(
+                    runner_attribute_file=attribute_file_path, **kwargs
+                )
 
             pid = await self.spm.async_run_command(
                 [sys.executable, *command],

--- a/metaflow/runner/subprocess_manager.py
+++ b/metaflow/runner/subprocess_manager.py
@@ -237,7 +237,7 @@ class CommandManager(object):
         self.command = command
 
         self.env = env if env is not None else os.environ.copy()
-        self.cwd = cwd if cwd is not None else os.getcwd()
+        self.cwd = cwd or os.getcwd()
 
         self.process = None
         self.stdout_thread = None

--- a/metaflow/runner/utils.py
+++ b/metaflow/runner/utils.py
@@ -322,3 +322,11 @@ def get_lower_level_group(
         raise ValueError(f"Sub-command '{sub_command}' not found in API '{api.name}'")
 
     return sub_command_obj(**sub_command_kwargs)
+
+
+@contextmanager
+def with_dir(new_dir):
+    current_dir = os.getcwd()
+    os.chdir(new_dir)
+    yield new_dir
+    os.chdir(current_dir)

--- a/metaflow/user_configs/config_options.py
+++ b/metaflow/user_configs/config_options.py
@@ -221,13 +221,13 @@ class ConfigInput:
         if param_name == "config_value":
             self._value_values = {
                 k.lower(): v
-                for k, v in param_value
+                for k, v in param_value.items()
                 if v is not None and not v.startswith(_CONVERTED_DEFAULT)
             }
         else:
             self._path_values = {
                 k.lower(): v
-                for k, v in param_value
+                for k, v in param_value.items()
                 if v is not None and not v.startswith(_CONVERTED_DEFAULT)
             }
         if do_return:
@@ -329,11 +329,11 @@ class ConfigInput:
                 to_return[name] = None
                 flow_cls._flow_state[_FlowState.CONFIGS][name] = None
                 continue
-            if val.startswith(_CONVERTED_DEFAULT_NO_FILE):
-                no_default_file.append(name)
-                continue
             if val.startswith(_CONVERTED_NO_FILE):
                 no_file.append(name)
+                continue
+            if val.startswith(_CONVERTED_DEFAULT_NO_FILE):
+                no_default_file.append(name)
                 continue
 
             val = val[len(_CONVERT_PREFIX) :]  # Remove the _CONVERT_PREFIX
@@ -398,7 +398,7 @@ class ConfigInput:
         return self.process_configs(
             ctx.obj.flow.name,
             param.name,
-            value,
+            dict(value),
             ctx.params["quiet"],
             ctx.params["datastore"],
             click_obj=ctx.obj,

--- a/test/test_config/config_corner_cases.py
+++ b/test/test_config/config_corner_cases.py
@@ -1,0 +1,108 @@
+import json
+import os
+
+from metaflow import (
+    Config,
+    FlowSpec,
+    Parameter,
+    config_expr,
+    current,
+    environment,
+    project,
+    step,
+)
+
+default_config = {"a": {"b": "41", "project_name": "config_project"}}
+
+
+def audit(run, parameters, configs, stdout_path):
+    # We should only have one run here
+    if len(run) != 1:
+        raise RuntimeError("Expected only one run; got %d" % len(run))
+    run = run[0]
+
+    # Check successful run
+    if not run.successful:
+        raise RuntimeError("Run was not successful")
+
+    if configs and configs.get("cfg_default_value"):
+        config = configs["cfg_default_value"]
+    else:
+        config = default_config
+
+    expected_token = parameters["trigger_param"]
+
+    # Check that we have the proper project name
+    if f"project:{config['a']['project_name']}" not in run.tags:
+        raise RuntimeError("Project name is incorrect.")
+
+    # Check the value of the artifacts in the end step
+    end_task = run["end"].task
+    assert end_task.data.trigger_param == expected_token
+    if (
+        end_task.data.config_val != 5
+        or end_task.data.config_val_2 != config["a"]["b"]
+        or end_task.data.config_from_env != "5"
+        or end_task.data.config_from_env_2 != config["a"]["b"]
+        or end_task.data.var1 != "1"
+        or end_task.data.var2 != "2"
+    ):
+        raise RuntimeError("Config values are incorrect.")
+
+    return None
+
+
+def trigger_name_func(ctx):
+    return [current.project_flow_name + "Trigger"]
+
+
+# Use functions in config_expr
+def return_name(cfg):
+    return cfg.a.project_name
+
+
+@project(name=config_expr("return_name(cfg_default_value)"))
+class ConfigSimple(FlowSpec):
+
+    trigger_param = Parameter(
+        "trigger_param",
+        default="",
+        external_trigger=True,
+        external_artifact=trigger_name_func,
+    )
+    cfg = Config("cfg", default="config_simple.json")
+    cfg_default_value = Config(
+        "cfg_default_value",
+        default_value=default_config,
+    )
+    env_cfg = Config("env_cfg", default_value={"VAR1": "1", "VAR2": "2"})
+
+    @environment(
+        vars={
+            "TSTVAL": config_expr("str(cfg.some.value)"),
+            "TSTVAL2": cfg_default_value.a.b,
+        }
+    )
+    @step
+    def start(self):
+        self.config_from_env = os.environ.get("TSTVAL")
+        self.config_from_env_2 = os.environ.get("TSTVAL2")
+        self.config_val = self.cfg.some.value
+        self.config_val_2 = self.cfg_default_value.a.b
+        self.next(self.mid)
+
+    # Use config_expr as a top level attribute
+    @environment(vars=config_expr("env_cfg"))
+    @step
+    def mid(self):
+        self.var1 = os.environ.get("VAR1")
+        self.var2 = os.environ.get("VAR2")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        pass
+
+
+if __name__ == "__main__":
+    ConfigSimple()

--- a/test/unit/test_config_value.py
+++ b/test/unit/test_config_value.py
@@ -1,0 +1,95 @@
+import json
+
+import pytest
+
+from metaflow.user_configs.config_parameters import ConfigValue
+
+
+def test_isinstance():
+    orig_dict = {"a": 1, "b": 2}
+    c_value = ConfigValue(orig_dict)
+    assert isinstance(c_value, dict)
+
+
+def test_todict():
+    orig_dict = {"a": 1, "b": 2}
+    c_value = ConfigValue(orig_dict)
+    assert c_value.to_dict() == orig_dict
+
+    orig_dict = {"a": 1, "b": [1, 2, 3], "c": {"d": 4}, "e": {"f": [{"g": 5}]}}
+    c_value = ConfigValue(orig_dict)
+    assert c_value.to_dict() == orig_dict
+
+
+def test_container_has_config_value():
+    orig_dict = {
+        "a": 1,
+        "b": [1, 2, 3],
+        "c": {"d": 4},
+        "e": {"f": [{"g": 5}]},
+        "h": ({"i": 6},),
+    }
+    c_value = ConfigValue(orig_dict)
+    assert c_value.e.f[0].g == 5
+    assert isinstance(c_value.c, ConfigValue)
+    assert isinstance(c_value.e, ConfigValue)
+    assert isinstance(c_value.e.f, list)
+    assert isinstance(c_value.e.f[0], ConfigValue)
+    assert isinstance(c_value.h, tuple)
+    assert isinstance(c_value.h[0], ConfigValue)
+
+
+def test_non_modifiable():
+    orig_dict = {"a": 1, "b": 2, "c": 3}
+    c_value = ConfigValue(orig_dict)
+    with pytest.raises(TypeError):
+        c_value["d"] = 4
+    with pytest.raises(TypeError):
+        c_value.popitem()
+    with pytest.raises(TypeError):
+        c_value.pop("a", 5)
+    with pytest.raises(TypeError):
+        c_value.clear()
+    with pytest.raises(TypeError):
+        c_value.update({"e": 6})
+    with pytest.raises(TypeError):
+        c_value.setdefault("f", 7)
+    with pytest.raises(TypeError):
+        del c_value["b"]
+
+    assert c_value.to_dict() == orig_dict
+
+
+def test_json_dumpable():
+    orig_dict = {
+        "a": 1,
+        "b": [1, 2, 3],
+        "c": {"d": 4},
+        "e": {"f": [{"g": 5}]},
+        "h": ({"i": 6},),
+    }
+    c_value = ConfigValue(orig_dict)
+    assert json.loads(json.dumps(c_value)) == json.loads(json.dumps(orig_dict))
+
+
+def test_dict_like_behavior():
+    orig_dict = {
+        "a": 1,
+        "b": [1, 2, 3],
+        "c": {"d": 4},
+        "e": {"f": [{"g": 5}]},
+        "h": ({"i": 6},),
+    }
+    c_value = ConfigValue(orig_dict)
+    assert "a" in c_value
+    assert "d" not in c_value
+    assert len(c_value) == 5
+    assert c_value.keys() == orig_dict.keys()
+    for k, v in c_value.items():
+        assert v == orig_dict[k]
+
+    for k in c_value.keys():
+        assert k in orig_dict
+
+    for v in c_value.values():
+        assert v in orig_dict.values()


### PR DESCRIPTION
Recreated from original PR: https://github.com/Netflix/metaflow/pull/2409

Now allows:
@environment(vars=config_expr("..."))
  - This was broken since vars was a ConfigValue and not an updatable dictionary

@project(name=config_expr("get_my_name(cfg)"))
  - This was broken because when evaluating the config_expr, we did not consider the globals at the point of call but instead inside the file defining config_expr.

Tests are deployed internally.